### PR TITLE
Make Ron a possible exec (fix #2)

### DIFF
--- a/compsoc-constitution.tex
+++ b/compsoc-constitution.tex
@@ -310,9 +310,8 @@ Edinburgh Computing and Artificial Intelligence Society''.
   \item When elections are held there will always be an option to re-open nominations.
     This option will be presented as an additional candidate, “Ron”.
     If Ron gets the greatest amount of votes the position will be kept open
-    and an EGM shall be called by the committee to fill the position. There
-    will not be a “Ron” candidate for the positions of President, Secretary,
-    Treasurer. Nominations may be made at the AGM, subject to the nominee's
+    and an EGM shall be called by the committee to fill the position.
+    Nominations may be made at the AGM, subject to the nominee's
     consent.
 
   \item If no nominations are received for any of President, Secretary or Treasurer,


### PR DESCRIPTION
- According to EUSA regulations (see #2), RON needs to be an option for all positions.
- This proposal removes the following clause:
    
    >  There will not be a “Ron” candidate for the positions of President, Secretary, Treasurer.