### PR TITLE
Replace cheque clause with signatory clause

### DIFF
--- a/compsoc-constitution.tex
+++ b/compsoc-constitution.tex
@@ -75,7 +75,7 @@ Edinburgh Computing and Artificial Intelligence Society''.
 
   \item All members who are not matriculated students of a University shall pay at least twice the annual subscription.
 
-  \item The society’s cheques must require two signatories; Taking two from the Treasurer, President and Secretary.
+  \item The society’s bank account must have the President, Secretary, and Treasurer added as signatories.
 
   \item The society has taken and will continue to take all necessary steps to ensure that our meetings, events and socials are accessible to all, irrespective of any disability. 
 


### PR DESCRIPTION
Nowadays cheques are rarely used and our bank, Santander, no longer provides the ability to require two signatories for cheques.

This clause ensures that the President, Secretary, and Treasurer are added as signatories to the bank account.

This PR supersedes #6.