### PR TITLE
Rename longform name of society

### DIFF
--- a/compsoc-constitution.tex
+++ b/compsoc-constitution.tex
@@ -30,7 +30,7 @@
 \begin{document}
 
 \title{CompSoc Constitution}
-\author{The University of Edinburgh Computing \& Artificial Intelligence Society}
+\author{The University of Edinburgh Technology Society}
 \date{\today{}}
 \maketitle
 


### PR DESCRIPTION
This commit renames "The University of Edinburgh Computing and
Artificial Intelligence Society" to "The University of Edinburgh
Technology Society".

CompSoc caters to more than just Informatics students and we run events
for the wider technological community. A large number of members also
aim to follow a career in technology (but not necessarily computer
science or software engineering related jobs).

This commit would better represent the wide range of events we run and
better represent our wide cohort of members.

In addition, there are numberous "Technology Societies" around the
United Kingdom and we would simply joining the other societies in
running fantastic events for the wider technology community.

Finally, nobody currently calls "CompSoc" the "Computing and Artificial
Intelligence Society" (our official name), and we will continue
to use the "CompSoc" brand as it is already very well established.