### PR TITLE
2020 constitution update #2

### DIFF
--- a/sections/sigs.tex
+++ b/sections/sigs.tex
@@ -32,7 +32,7 @@
       group.
     \end{enumerate}
 
-  \item New SIGs must be approved by two thirds of the committee.
+  \item New SIGs must be approved by two thirds of the elected committee.
 
   \item Once an SIG is accepted:-
     \begin{enumerate}
@@ -54,7 +54,7 @@
     enough events, the SIG may be included in the constitution.
 
   \item If the committee feels a SIG’s activities has become incompatible with
-    the interests and aims of the society, the committee may, by a two third
+    the interests and aims of the society, the elected committee may, by a two third
     majority, decide to dis-associate CompSoc from the SIG.
 
   \subsection{Leadership of SIGs}


### PR DESCRIPTION
This constitutional change will be discussed at the EGM on the 23rd of October, and aims to limit SIG creation/dissolution to elected committee members only (i.e. not SIG leaders).