### PR TITLE
Remove reference to LawTech

### DIFF
--- a/sections/sigs.tex
+++ b/sections/sigs.tex
@@ -11,7 +11,6 @@
   \item SIGWeb: Web Development
   \item HackSIG\@: Hackathons
   \item SIGINT\@: Cyber Security Group
-  \item LawTech: The Law and Technology Group
   \item SIGnet: Computer Networking
   \end{itemize}
 


### PR DESCRIPTION
LawTech has asked to secede as a SIG from CompSoc. This constitutional amendment reflects that they are no longer considered a SIG.