### PR TITLE
Update the SIG member minimum to 10 

### DIFF
--- a/sections/sigs.tex
+++ b/sections/sigs.tex
@@ -18,8 +18,8 @@
 \item The following points will be considered by the committee when processing the application of a new SIG\@:
   \begin{enumerate}
   \item The SIG should have a clearly defined goal, purpose or other reason for existence deemed appropriate by the committee.
-  \item The SIG should have at least 4 members. In extraordinary circumstances this can be overruled by the vote of 2/3 of the committee.
-  \item The SIG should have current CompSoc-member as a leader. The leader shall be responsible for running the group and reporting back to the Vice President and the CompSoc committee. It is encouraged that the selection of a leader should be done democratically within the group.
+  \item The SIG should have at least 10 members. In extraordinary circumstances this can be overruled by the vote of 2/3 of the committee.
+  \item The SIG should have current CompSoc-member as a leader. The leader shall be responsible for running the group and reporting back to the CompSoc committee. It is encouraged that the selection of a leader should be done democratically within the group.
   \end{enumerate}
 
 \item New SIGs must be approved by two thirds of the elected committee.


### PR DESCRIPTION
As discussed in the Committee meeting on the 27th September with 11/12, we're raising the minimum recommended member count of SIGs from 4 to 10. This amendment will be voted upon on the EGM on the 25th October 2023.