### PR TITLE
change EDI rep to elected position

### DIFF
--- a/sections/committee.tex
+++ b/sections/committee.tex
@@ -56,6 +56,7 @@
   \item The Hack Secretary shall be responsible for organising and assembling an organisation team/SIG for any hackathons the committee wishes to run.
   \item The Technical Secretary shall be responsible for maintaining any servers and services that the society is running for both the committee and members. The Tech Sec will also be responsible for any technical setups for society events.
   \item The Graphic Designer shall be responsible for the creation of art, logos, and other designs required by the society for events, merchandise and other promotional material.
+  \item The EDI (equality, diversity and inclusion) Officer shall be responsible for ensuring that the society is inclusive and welcoming to all students, and that the society is accessible to all students.
   \end{enumerate}
 
   It is important to note that the above are suggestions to what those elected to the positions should be responsible, not absolute rules. Delegation is encouraged and necessary, but those in the relevant positions should take responsibility for delegating the tasks and making sure they get done.
@@ -63,7 +64,6 @@
 \item Non elected positions on the committee are as follows:
   \begin{enumerate}
   \item To ensure cooperation between the School of Informatics and CompSoc, the school convenors for the School of Informatics automatically have a place and vote on the committee, to vote on behalf of the school. It is entirely up to the representative to what degree they wish to participate in the committee.
-  \item An EDI Representiative role created and managed by the School of Informatics will automatically have a place and vote on the committee.
   \item The leaders of the Special Interest Groups have a place and vote on the committee (see below, \enquote{Special Interest Groups}).
   \end{enumerate}
 


### PR DESCRIPTION
We are changing the EDI rep role to an elected position as the School of Informatics no longer appoints an EDI rep. This change is to be voted on in the EGM on 31/01/2024.